### PR TITLE
Redirection decp.info → colibre.fr en 301 sous YunoHost #57

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,22 @@ _MIGRATIONS = [
 - `main` branch → manual deploy to colibre.fr via GitHub Actions
 - `dev` branch → auto-deploy to test.colibre.fr via GitHub Actions
 
+#### Redirection decp.info → colibre.fr
+
+Deux configurations nginx selon le serveur :
+
+- nginx **standalone** : `deploy/nginx-colibre.conf` (vhost complet, à lier dans
+  `sites-enabled`)
+- **YunoHost** : `deploy/nginx-yunohost-decp-info.conf` (301) et
+  `deploy/nginx-yunohost-test-decp-info.conf` (302), à déposer dans
+  `/etc/nginx/conf.d/<domaine>.d/`
+
+L'app YunoHost `redirect_ynh` n'est pas utilisable : son template code en dur
+`return 302`, et le choix 301 n'existe que dans la PR amont #69, non fusionnée.
+
+Sous YunoHost, aucune app ne doit occuper la racine `/` du domaine redirigé
+(`yunohost app map`), sinon nginx échoue sur `duplicate location "/"`.
+
 #### Sauvegarde de la base utilisateurs
 
 `users.sqlite` est sauvegardée toutes les heures sur S3 par un timer systemd

--- a/deploy/nginx-colibre.conf
+++ b/deploy/nginx-colibre.conf
@@ -1,4 +1,10 @@
-# Configuration nginx de référence pour colibre.fr + migration decp.info.
+# Configuration nginx de référence pour colibre.fr + migration decp.info,
+# pour un nginx **standalone** (sites-available/sites-enabled).
+#
+# Sur un serveur YunoHost, ne PAS utiliser ce fichier : YunoHost génère
+# lui-même /etc/nginx/conf.d/<domaine>.conf et écraserait ce vhost. Utiliser
+# les snippets deploy/nginx-yunohost-decp-info.conf et
+# deploy/nginx-yunohost-test-decp-info.conf à la place.
 #
 # Installation (sur le serveur, en root) :
 #   cp deploy/nginx-colibre.conf /etc/nginx/sites-available/colibre

--- a/deploy/nginx-yunohost-decp-info.conf
+++ b/deploy/nginx-yunohost-decp-info.conf
@@ -1,0 +1,48 @@
+# Redirection permanente decp.info → colibre.fr, pour un serveur YunoHost.
+#
+# À utiliser À LA PLACE de deploy/nginx-colibre.conf quand nginx est piloté par
+# YunoHost : YunoHost génère lui-même /etc/nginx/conf.d/<domaine>.conf et écrase
+# tout vhost concurrent. On ne fournit donc qu'un *snippet* déposé dans le
+# répertoire d'inclusion du domaine.
+#
+# Pourquoi pas l'app YunoHost « redirect » : son template nginx code en dur
+# `return 302` (conf/nginx-redirect.conf). Le choix 301 n'existe que dans la PR
+# amont #69, non fusionnée. Pour une migration de domaine il faut une 301, qui
+# transfère l'autorité SEO — d'où ce snippet, sans dépendance ni app à maintenir.
+#
+# Installation (sur le serveur, en root) :
+#   cp deploy/nginx-yunohost-decp-info.conf \
+#      /etc/nginx/conf.d/decp.info.d/zzz-redirect-colibre.conf
+#   # www.decp.info est un domaine YunoHost distinct : même fichier à copier
+#   # dans son propre répertoire d'inclusion, s'il est déclaré.
+#   cp deploy/nginx-yunohost-decp-info.conf \
+#      /etc/nginx/conf.d/www.decp.info.d/zzz-redirect-colibre.conf
+#   nginx -t && systemctl reload nginx
+#
+# Le préfixe « zzz- » garantit l'inclusion en dernier (les fichiers du
+# répertoire .d sont lus dans l'ordre alphabétique) : si une app YunoHost pose
+# un jour un bloc plus spécifique, il reste prioritaire.
+#
+# Prérequis : AUCUNE app YunoHost ne doit être installée à la racine « / » de
+# decp.info, sinon nginx refuse de démarrer (« duplicate location "/" »).
+# Vérifier avec `yunohost app map`, et désinstaller/déplacer l'app concernée
+# (historiquement « decpinfo ») avant de déposer ce fichier.
+#
+# Ce snippet n'est inclus que dans le vhost 443 : le vhost 80 généré par
+# YunoHost redirige déjà vers HTTPS et sert les challenges ACME lui-même, sans
+# inclure le répertoire .d (cf. conf/nginx/server.tpl.conf amont). Le
+# renouvellement des certificats n'est donc pas affecté.
+#
+# `yunohost tools regen-conf nginx` ne régénère que <domaine>.conf ; ce fichier
+# ajouté manuellement dans .d survit aux régénérations et aux mises à jour.
+
+# 301 permanente, chemin et query string préservés via $request_uri :
+#   https://decp.info/marche?id=123 → https://colibre.fr/marche?id=123
+# La structure d'URL est identique entre les deux domaines (rebranding), donc
+# chaque ancienne URL garde son équivalent — on NE redirige PAS tout vers la
+# home, ce qui transfèrerait mal l'autorité SEO.
+#
+# Pas de slash final sur la cible : « https://colibre.fr/ » produirait « //marche ».
+location / {
+    return 301 https://colibre.fr$request_uri;
+}

--- a/deploy/nginx-yunohost-test-decp-info.conf
+++ b/deploy/nginx-yunohost-test-decp-info.conf
@@ -1,0 +1,16 @@
+# Redirection test.decp.info → test.colibre.fr, pour un serveur YunoHost.
+#
+# Variante « test » de deploy/nginx-yunohost-decp-info.conf ; voir ce fichier
+# pour le détail de l'installation, des prérequis et du fonctionnement.
+#
+# Installation (sur le serveur, en root) :
+#   cp deploy/nginx-yunohost-test-decp-info.conf \
+#      /etc/nginx/conf.d/test.decp.info.d/zzz-redirect-colibre.conf
+#   nginx -t && systemctl reload nginx
+
+# 302 temporaire — et non 301 comme en prod. Tant que l'environnement de test
+# est susceptible de bouger, on évite qu'un navigateur ou un moteur mette en
+# cache une redirection qui n'est pas définitive.
+location / {
+    return 302 https://test.colibre.fr$request_uri;
+}

--- a/src/pages/a_propos/abonnement.py
+++ b/src/pages/a_propos/abonnement.py
@@ -100,9 +100,7 @@ def _subscribe_button(
         return html.Div(
             [
                 dbc.Alert(
-                    "Les fonctionnalités normalement accessibles contre un abonnement "
-                    "mensuel sont accessibles à tous et toutes en attendant "
-                    "la validation du dossier pour recevoir des paiements par carte bancaire.",
+                    "Les fonctionnalités normalement accessibles contre un abonnement sont temporairement accessibles gratuitement.",
                     color="info",
                 ),
                 html.A(

--- a/src/pages/a_propos/donnees.py
+++ b/src/pages/a_propos/donnees.py
@@ -37,7 +37,7 @@ Vous pouvez consommer les données qui alimentent colibre en les téléchargeant
 pensez à lire la description du jeu de données
 
 Une API REST tabulaire (JSON) est également disponible par abonnement mensuel pour accéder aux mêmes données et alimenter une application.
-Documentation interactive : [Swagger UI](/api/v1/swagger). Si cela vous intéresse, [envoyez un message](/a-propos/contact)."""),
+Documentation interactive : [Swagger UI](/api/v1/swagger). Si vous souhaitez utiliser l'API, [envoyez un message](/a-propos/contact)."""),
             html.H2("Qualité et exhaustivité des données", className="mt-4"),
             dcc.Markdown(
                 """Les données visibles sur ce site proviennent exclusivement de la publication de données

--- a/src/pages/a_propos/presentation.py
+++ b/src/pages/a_propos/presentation.py
@@ -17,10 +17,11 @@ def layout(**_):
         [
             html.H2("Présentation"),
             dcc.Markdown(
-                """Outil d'exploration libre des données de marchés publics, développé par Colin Maudry via la société [Colmo](https://annuaire-entreprises.data.gouv.fr/entreprise/colmo-989393350).
+                """Outil d'exploration des données de marchés publics, en [licence libre](/a-propos/explorer) et [100 % Open Data](/a-propos/donnees), développé par Colin Maudry via la société [Colmo](https://annuaire-entreprises.data.gouv.fr/entreprise/colmo-989393350).
 
-Ce projet vise à démocratiser l'accès aux données des marchés publics dans un outil performant en grande partie gratuit.
-Si vous le trouvez utile, [envoyez un message](/a-propos/contact) pour exposer vos cas d'usages et vos besoins. Cet outil ne peut rester
+Ce projet vise à démocratiser l'accès aux données des marchés publics dans un outil performant en grande partie gratuit. Il vise à lutter contre l'opacité de la commande publique et à
+permettre à un large public de mieux comprendre qui achète quoi, à qui, pour combien, etc. Si vous le trouvez utile, [envoyez un message](/a-propos/contact) pour exposer
+vos cas d'usages et vos besoins. Cet outil ne peut rester
 performant qu'avec la connaissance des problèmes à résoudre.
 Ce projet est financé par ses [abonné·es](/a-propos/abonnement) et par des missions de conseil et de développement.
 


### PR DESCRIPTION
Refs #57.

## Contexte

L'app YunoHost [`redirect_ynh`](https://github.com/YunoHost-Apps/redirect_ynh) ne convient pas : son template `conf/nginx-redirect.conf` code en dur `return 302 __TARGET__$request_uri;`, il n'y a pas de `config_panel.toml` pour le changer, et le choix 301 n'existe que dans la [PR amont #69](https://github.com/YunoHost-Apps/redirect_ynh/pull/69), ouverte depuis octobre 2025 et non fusionnée. Une migration de domaine demande une 301 pour transférer l'autorité SEO.

D'où deux snippets nginx sans dépendance ni app à maintenir, à déposer dans le répertoire d'inclusion du domaine généré par YunoHost.

## Contenu

- `deploy/nginx-yunohost-decp-info.conf` — 301 vers `colibre.fr` (également à copier pour `www.decp.info`, domaine YunoHost distinct)
- `deploy/nginx-yunohost-test-decp-info.conf` — 302 vers `test.colibre.fr`, tant que l'environnement de test peut bouger
- `deploy/nginx-colibre.conf` — en-tête complété : réservé à un nginx **standalone**, à ne pas utiliser sous YunoHost
- `CLAUDE.md` — section « Redirection decp.info → colibre.fr »

## Points de conception

- Le chemin et la query string sont préservés via `$request_uri`.
- Le snippet n'atterrit que dans le vhost 443 : le vhost 80 généré par YunoHost gère déjà ACME et la redirection HTTPS **sans** inclure le répertoire `.d` (cf. `conf/nginx/server.tpl.conf` amont), donc le renouvellement des certificats n'est pas affecté.
- Préfixe `zzz-` pour une inclusion en dernier ; les blocs plus spécifiques (`/yunohost/sso`, etc.) restent prioritaires par la règle du plus long préfixe.
- Pas de slash final sur la cible, sinon `//marche`.

## Prérequis de déploiement

Aucune app YunoHost ne doit occuper la racine `/` de `decp.info` (`yunohost app map`), sinon nginx échoue sur `duplicate location "/"`. L'app historique `decpinfo` doit donc être désinstallée ou déplacée avant de déposer le fichier.

## Vérification

Snippets montés dans un conteneur `nginx:alpine` avec un vhost reproduisant l'inclusion YunoHost :

- `nginx -t` : OK
- `decp.info/` → `301` → `https://colibre.fr/`
- `decp.info/marche?id=123` → `301` → `https://colibre.fr/marche?id=123`
- `decp.info/acheteur/213105554/stats?annee=2024&x=a%20b` → `301` → même URI préservée, encodage compris
- `test.decp.info/tableau?q=1` → `302` → `https://test.colibre.fr/tableau?q=1`
- `decp.info/yunohost/sso` → `200` (bloc plus spécifique non capturé par `location /`)

Pas de double slash observé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)